### PR TITLE
Fix integer overflow causing a risk of a freeze every ~71 minutes.

### DIFF
--- a/src/rp2040/core0.c
+++ b/src/rp2040/core0.c
@@ -33,11 +33,11 @@ void recover_clock() {
   static struct Ring_buf_uint_ave time_average_data_1;
   static struct Ring_buf_uint_ave time_average_data_2;
   static size_t time_last = 0;
-  uint32_t restart_at = 0;
+  uint64_t restart_at = 0;
   uint32_t last_ave_period_us = 0;
 
   // Record the average length of time between packets.
-  size_t time_now = time_us_64();
+  uint64_t time_now = time_us_64();
   uint32_t ave_period_us = ring_buf_uint_ave(&period_average_data, time_now - time_last);
   time_last = time_now;
 


### PR DESCRIPTION
The time counter (size_t = 32 bits long) overflows after 2**32 µs = ~71 minutes. Sometimes the condition for the while loop to end (line 68) won't be true for another ~71 minutes or a multiple.

This happens when restart_at might be set to close to 2**32 but time_now might have already overflown the 32-bit counter.

size_t (used for time_now) is 64 bits on an 64-bit x86_64, but is only 32 bits on small ARM microcontrollers.